### PR TITLE
add xdebug to homework project

### DIFF
--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -3,4 +3,8 @@ FROM php:8.1-apache
 RUN apt-get update \
     && apt-get install libpq-dev -y \
     && docker-php-ext-install pdo_pgsql \
+    && pecl install xdebug \
+    && docker-php-ext-enable xdebug \
+    && echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+    && echo "xdebug.client_host=172.17.0.1" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && apt-get clean

--- a/index.php
+++ b/index.php
@@ -1,22 +1,5 @@
 <?php
 require_once __DIR__ . '/vendor/autoload.php';
 
-function sendNotification(\app\homework\hw_6\contracts\SenderInterface $sender) {
-    $sender->send();
-}
-
-$emailNofitication = new \app\homework\hw_6\EmailNotification(
-    'test@gmail.com',
-    'TestMessage'
-);
-$emailNofitication->setMessage('Test Email message');
-
-$smsNotification = new \app\homework\hw_6\SmsNotification('380999999999');
-$smsNotification->setMessage('Test SMS message');
-
-sendNotification($emailNofitication);
-sendNotification($smsNotification);
-
-
-$test = new \app\homework\hw_6\Test();
-echo $test->getSum();
+phpinfo();
+die;


### PR DESCRIPTION
# instruction

1. run `docker-compose up -d --build`
2. adjust the phpstorm config
   - `Setting > PHP > debug`
   - enable `Automatically detect IDE IP`
![image](https://user-images.githubusercontent.com/18249681/182027230-bd0c104b-3eb3-43e4-8b11-52618deb8c61.png)
   - enable listening for php debug connection 
![image](https://user-images.githubusercontent.com/18249681/182027344-5de822f6-a820-4c95-80a0-84e234298b8c.png)
   - add extension to your browser `https://chrome.google.com/webstore/detail/xdebug-chrome-extension/oiofkammbajfehgpleginfomeppgnglk`   
![image](https://user-images.githubusercontent.com/18249681/182027405-c619eaaf-84e2-4a50-aab9-ba7a0e935275.png)
3. add red point to any line in your code
![image](https://user-images.githubusercontent.com/18249681/182027457-055bfdd7-7d46-4241-8780-a48f378cf303.png)
4. go to `http://localhost:8080/`
5. you should see the debug mode 
![image](https://user-images.githubusercontent.com/18249681/182027493-6bfcaa13-1d5e-4b5e-9207-25654d55e307.png)
